### PR TITLE
Fix ARM CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ AJAX interface to allow users to manage their own calendars and shared ones.
 #### Supported architectures
 
 * x86-64b - [![Build Status](https://ci-apps.yunohost.org/ci/logs/agendav%20%28Apps%29.svg)](https://ci-apps.yunohost.org/ci/apps/agendav/)
-* ARMv8-A - [![Build Status](https://ci-apps-arm.yunohost.org/ci/logs/agendav%20%28Apps%29.svg)](https://ci-apps-arm.yunohost.org/ci/apps/agendav/)
+* ARMv8-A - [![Build Status](https://ci-apps-arm.yunohost.org/ci/logs/agendav%20%28Apps%29%20%28&#126;ARM&#126;%29.svg)](https://ci-apps-arm.yunohost.org/ci/apps/agendav/)
 * Jessie x86-64b - [![Build Status](https://ci-stretch.nohost.me/ci/logs/agendav%20%28Apps%29.svg)](https://ci-stretch.nohost.me/ci/apps/agendav/)
 
 ## Limitations


### PR DESCRIPTION
## Problem
The CI badge for the ARM build does not show.

## Solution
Use the new URL.

Please note, I am not sure why we're escaping characters with HTML escape codes but I tried to follow that convention. I used https://www.freeformatter.com/html-entities.html as a reference and checked it rendered correctly locally with https://pypi.org/project/grip/.

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/agendav_ynh%20PR40/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/agendav_ynh%20PR40/)  