### PR TITLE
Upgrade to 2.2.1 - /!\ Requires YunoHost patch, please read only

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you don't have YunoHost, please see [here](https://yunohost.org/#/install) to
 
 [AgenDAV](http://agendav.org/) is a CalDAV web client which features an AJAX interface to allow users to manage their own calendars and shared ones.
 
-**Shipped version:** 2.2.0
+**Shipped version:** 2.2.1
 
 ## Screenshots
 
@@ -24,7 +24,7 @@ If you don't have YunoHost, please see [here](https://yunohost.org/#/install) to
 
 ## Documentation
 
- * Official documentation: http://docs.agendav.org/en/2.2.0/
+ * Official documentation: http://docs.agendav.org/en/2.2.1/
  * YunoHost documentation: If specific documentation is needed, feel free to contribute.
 
 ## YunoHost specific features

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/adobo/agendav/releases/download/2.2.0/agendav-2.2.0.tar.gz
-SOURCE_SUM=0056154ae0a7aa3401f4f24c51f0f2de3d1e97eaa83e74a2129714b67013129f
+SOURCE_URL=https://github.com/adobo/agendav/releases/download/2.2.1/agendav-2.2.1.tar.gz
+SOURCE_SUM=7e293fc20660646bfb17e2af180f35cb5a8151664724238b569b3939c34b5f24
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
     },
     "url": "http://agendav.org/",
     "license": "GPL-3.0",
-    "version": "2.2.0~ynh2",
+    "version": "2.2.1~ynh1",
     "maintainer": {
         "name": "julien",
         "email": "julien.malik@paraiso.me"

--- a/sources/patches/app-00-add-http-auth.patch
+++ b/sources/patches/app-00-add-http-auth.patch
@@ -1,3 +1,5 @@
+diff --git a/web/app/controllers.php b/web/app/controllers.php
+index 08db57e3..3d186c5e 100644
 --- a/web/app/controllers.php
 +++ b/web/app/controllers.php
 @@ -58,14 +58,20 @@ $controllers->before(function(Request $request, Silex\Application $app) {
@@ -27,7 +29,7 @@
 +            return;
 +        }
      }
-
+ 
      if ($request->isXmlHttpRequest()) {
 diff --git a/web/src/Controller/Authentication.php b/web/src/Controller/Authentication.php
 index deebb751..134cc9a8 100644
@@ -36,7 +38,7 @@ index deebb751..134cc9a8 100644
 @@ -34,9 +34,14 @@ class Authentication
          $success = false;
          $template_vars = [];
-
+ 
 -        if ($request->isMethod('POST')) {
 -            $user = $request->request->get('user');
 -            $password = $request->request->get('password');
@@ -48,6 +50,6 @@ index deebb751..134cc9a8 100644
 +                $user = $request->request->get('user');
 +                $password = $request->request->get('password');
 +            }
-
+ 
              if (empty($user) || empty($password)) {
                  $template_vars['error'] = $app['translator']->trans('messages.error_empty_fields');


### PR DESCRIPTION
## Problem

- Fixes #54

## Solution

- Upgrade to 2.2.1

## PR Status

There remains an issue with EOL lines and this line must add `--binary` to the `patch` arguments: https://github.com/YunoHost/yunohost/blob/dev/data/helpers.d/utils#L222 (the files from the agendav archive use CRLF line endings and not LF anymore).

I don't know how to do that properly but I am opening this PR in the hope someone can help.