### PR TITLE
[upgrade] Fix missing whitespace breaking upgrade

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -112,7 +112,7 @@ then
 	ynh_script_progression --message="Upgrading source files..." --weight=1
 
 	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir="$final_path"--keep="web/config/settings.php"
+	ynh_setup_source --dest_dir="$final_path" --keep="web/config/settings.php"
 fi
 
 chmod 750 "$final_path"


### PR DESCRIPTION
## Problem

- Fix an issue with the upgrade creating a 'agendav--keep=web'" directory in /var/www

## Solution

- Fix a typo

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
