### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -60,7 +60,7 @@ encryptkey=$(ynh_string_random --length=24)
 ynh_app_setting_set --app="$app" --key=encryptkey --value="$encryptkey"
 
 # Copy and set AgenDAV configuration
-timezone=$(cat /etc/timezone)
+timezone=$(timedatectl show --value --property=Timezone)
 
 caldav_domain=$(ynh_app_setting_get --app=$caldav_app --key=domain)
 caldav_path=$(ynh_app_setting_get --app=$caldav_app --key=path)

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -64,7 +64,7 @@ ynh_use_logrotate --non-append
 ynh_script_progression --message="Updating a configuration file..." --weight=2
 
 # Copy and set AgenDAV configuration
-timezone=$(cat /etc/timezone)
+timezone=$(timedatectl show --value --property=Timezone)
 
 caldav_domain=$(ynh_app_setting_get --app="$caldav_app" --key=domain)
 caldav_path=$(ynh_app_setting_get --app="$caldav_app" --key=path)


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.